### PR TITLE
タスクカードのタグを名前でソート

### DIFF
--- a/client/src/components/TaskPanel/TaskPanel.vue
+++ b/client/src/components/TaskPanel/TaskPanel.vue
@@ -33,7 +33,13 @@
           ></textarea>
           <div class="flex flex-wrap items-end gap-1 relative">
             <a @click="openingTagList = !openingTagList"><tag-icon /></a>
-            <task-tag v-for="tag in selectingTags" :key="tag.id" :tag="tag" />
+            <task-tag
+              v-for="tag in Array.from(selectingTags).sort((a, b) =>
+                a.name.localeCompare(b.name)
+              )"
+              :key="tag.id"
+              :tag="tag"
+            />
 
             <div
               v-if="openingTagList"

--- a/model/tag.go
+++ b/model/tag.go
@@ -38,7 +38,11 @@ func PutTag(ctx context.Context, tag *Tag) error {
 
 func GetTagMaps(ctx context.Context) (map[uuid.UUID][]uuid.UUID, error) {
 	var tagMaps []TagMap
-	err := GetDB(ctx).Find(&tagMaps).Error
+	err := GetDB(ctx).
+		Select("tag_maps.id as id, tag_maps.task_id as task_id, tag_maps.tag_id as tag_id").
+		Joins("right join tags on tag_maps.tag_id = tags.id").
+		Order("tags.name").
+		Find(&tagMaps).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- 付いているタグがソートされていなかった
- タスクの編集中に選択されているタグがソートされていなかった